### PR TITLE
RFC: macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ gzip -dc
 if test $? -eq 139; then
     exit 0 # We want this input
 else
-    exit 1 # We dont want this input
+    exit 1 # We don't want this input
 fi
 ```
 

--- a/bisect.c
+++ b/bisect.c
@@ -48,7 +48,7 @@
 //
 // The major complication in the mechanics of this is that we need to know if
 // the parent node succeeded or failed. If it succeeded then we just removed a
-// chunk and dont need to increment offset. If it failed, then we need to make
+// chunk and don't need to increment offset. If it failed, then we need to make
 // sure that chunk goes back.
 //
 
@@ -63,7 +63,7 @@ static gboolean kSkipEmpty = false;
 static gint kSkipThreshold = 0;
 
 static const GOptionEntry kBisectOptions[] = {
-    { "bisect-skip-empty", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kSkipEmpty, "Dont try to test empty input.", NULL },
+    { "bisect-skip-empty", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kSkipEmpty, "Don't try to test empty input.", NULL },
     { "bisect-skip-threshold", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT, &kSkipThreshold, "Skip truncated chunks smaller than this.", "bytes" },
     { NULL },
 };
@@ -90,7 +90,7 @@ static task_t * strategy_bisect_data(GNode *node)
     task_t *parent = node->data;        // The task above us in the tree.
     task_t *source = parent;            // Where we get our data from.
 
-    // We dont hold the lock on parent, but user data will never change.
+    // We don't hold the lock on parent, but user data will never change.
     bisect_t *parentstatus  = parent->user;
     bisect_t *childstatus   = g_new0(bisect_t, 1);
 
@@ -133,7 +133,7 @@ static task_t * strategy_bisect_data(GNode *node)
                 childstatus->offset,
                 childstatus->offset + childstatus->chunksize);
 
-        //  *If* the parent succeeded, then we increment offset, otherwise we dont need to.
+        //  *If* the parent succeeded, then we increment offset, otherwise we don't need to.
         // TODO: what if offset now >= size?
         childstatus->offset += childstatus->chunksize;
     } else {
@@ -179,7 +179,7 @@ static task_t * strategy_bisect_data(GNode *node)
     // OK, we can do a bisection now.
     child->fd = g_unlinked_tmp(NULL);
 
-    // I dont think this is possible.
+    // I don't think this is possible.
     if (childstatus->offset > source->size)
         goto nochildunlock;
 

--- a/bisect.c
+++ b/bisect.c
@@ -22,7 +22,6 @@
 #include <sys/uio.h>
 #include <sys/resource.h>
 #include <sys/types.h>
-#include <sys/sendfile.h>
 #include <sys/wait.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/flags.c
+++ b/flags.c
@@ -25,7 +25,7 @@
 // This file contains global knobs that can be controlled via command line options.
 //
 
-// Maximumum number of unprocessed workunits before we stop generating more.
+// Maximum number of unprocessed workunits before we stop generating more.
 // Each of these consumes a file descriptor, so cannot be infinite. Large
 // numbers might speed up minimizing very slow files, otherwise keep it small.
 // The problem is if you set this too high, we might go down the wrong path too

--- a/flags.h
+++ b/flags.h
@@ -19,6 +19,13 @@
 
 // This file is part of halfempty - a fast, parallel testcase minimization tool.
 
+#include <sys/resource.h>
+
+// Some OSes (e.g. macOS) define the number of RLIMITs under a different name.
+#if !defined(RLIMIT_NLIMITS) && defined(RLIM_NLIMITS)
+  #define RLIMIT_NLIMITS RLIM_NLIMITS
+#endif
+
 // See flags.c for documentation.
 extern guint kMaxUnprocessed;
 extern guint kCleanupThreads;

--- a/halfempty.c
+++ b/halfempty.c
@@ -65,12 +65,12 @@ static const GOptionEntry kDebugOptions[] = {
 };
 
 static const GOptionEntry kProcessOptions[] = {
-    { "no-terminate", 'k', G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &kKillFailedWorkers, "Dont terminate tests early if possible (default=terminate).", NULL },
+    { "no-terminate", 'k', G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &kKillFailedWorkers, "Don't terminate tests early if possible (default=terminate).", NULL },
     { "term-signal", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_INT, &kKillFailedWorkersSignal, "Signal to send discarded workers (default=15).", "signal" },
     { "timeout", 'T', G_OPTION_FLAG_NONE, G_OPTION_ARG_INT, &kMaxProcessTime, "Maximum child execution time (default=unlimited).", "seconds" },
     { "limit", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, decode_proc_limit, "Configure a child limit (ex. RLIMIT_CPU=60).", "RLIMIT_RESOURCE=N" },
-    { "inherit-stdout", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &kSilenceChildStdout, "Dont redirect child stdout to /dev/null (default=redirect)", NULL },
-    { "inherit-stderr", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &kSilenceChildStderr, "Dont redirect child stderr to /dev/null (default=redirect)", NULL },
+    { "inherit-stdout", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &kSilenceChildStdout, "Don't redirect child stdout to /dev/null (default=redirect)", NULL },
+    { "inherit-stderr", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &kSilenceChildStderr, "Don't redirect child stderr to /dev/null (default=redirect)", NULL },
     { NULL },
 };
 
@@ -78,8 +78,8 @@ static const GOptionEntry kStandardOptions[] = {
     { "output", 'o', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME, &kOutputFile, "Location to store minimized output (default=halfempty.out).", "filename" },
     { "stable", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kIterateUntilStable, "Re-run strategies until the result is stable (default=false).", NULL },
     { "quiet", 'q', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kQuiet, "Minimize all informational messages, try to only print errors (default=false).", NULL },
-    { "continue", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kContinueSearch, "Dont exit when finished, keep trying until interrupted (default=false).", NULL },
-    { "noverify", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &kVerifyInput, "Dont verify original input (faster, but can cause confusing errors) (default=false).", NULL },
+    { "continue", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kContinueSearch, "Don't exit when finished, keep trying until interrupted (default=false).", NULL },
+    { "noverify", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &kVerifyInput, "Don't verify original input (faster, but can cause confusing errors) (default=false).", NULL },
     { "monitor", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kMonitorMode, "Run dot (if installed) to monitor progress in your web browser (default=false).", NULL },
     { NULL },
 };

--- a/halfempty.c
+++ b/halfempty.c
@@ -21,7 +21,6 @@
 #include <sys/uio.h>
 #include <sys/resource.h>
 #include <sys/types.h>
-#include <sys/sendfile.h>
 #include <sys/wait.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/limits.c
+++ b/limits.c
@@ -130,10 +130,10 @@ static void __attribute__((constructor)) init_child_limits()
             g_warning("failed to getrlimit for %u, %m", i);
         }
 
-        g_debug("Configured rlimit %s => { %ld, %ld }",
+        g_debug("Configured rlimit %s => { %llu, %llu }",
                 limit_to_str(i),
-                kChildLimits[i].rlim_cur,
-                kChildLimits[i].rlim_max);
+                (unsigned long long)kChildLimits[i].rlim_cur,
+                (unsigned long long)kChildLimits[i].rlim_max);
     }
 
 

--- a/limits.c
+++ b/limits.c
@@ -41,22 +41,22 @@
 static const gchar * limit_to_str(uint8_t limit)
 {
     static const gchar * limits[UINT8_MAX] = {
-        [RLIMIT_CPU]        "RLIMIT_CPU",
-        [RLIMIT_FSIZE]      "RLIMIT_FSIZE",
-        [RLIMIT_DATA]       "RLIMIT_DATA",
-        [RLIMIT_STACK]      "RLIMIT_STACK",
-        [RLIMIT_CORE]       "RLIMIT_CORE",
-        [RLIMIT_RSS]        "RLIMIT_RSS",
-        [RLIMIT_NOFILE]     "RLIMIT_NOFILE",
-        [RLIMIT_AS]         "RLIMIT_AS",
-        [RLIMIT_NPROC]      "RLIMIT_NPROC",
-        [RLIMIT_MEMLOCK]    "RLIMIT_MEMLOCK",
-        [RLIMIT_LOCKS]      "RLIMIT_LOCKS",
-        [RLIMIT_SIGPENDING] "RLIMIT_SIGPENDING",
-        [RLIMIT_MSGQUEUE]   "RLIMIT_MSGQUEUE",
-        [RLIMIT_NICE]       "RLIMIT_NICE",
-        [RLIMIT_RTPRIO]     "RLIMIT_RTPRIO",
-        [RLIMIT_RTTIME]     "RLIMIT_RTTIME",
+        [RLIMIT_CPU]        = "RLIMIT_CPU",
+        [RLIMIT_FSIZE]      = "RLIMIT_FSIZE",
+        [RLIMIT_DATA]       = "RLIMIT_DATA",
+        [RLIMIT_STACK]      = "RLIMIT_STACK",
+        [RLIMIT_CORE]       = "RLIMIT_CORE",
+        [RLIMIT_RSS]        = "RLIMIT_RSS",
+        [RLIMIT_NOFILE]     = "RLIMIT_NOFILE",
+        [RLIMIT_AS]         = "RLIMIT_AS",
+        [RLIMIT_NPROC]      = "RLIMIT_NPROC",
+        [RLIMIT_MEMLOCK]    = "RLIMIT_MEMLOCK",
+        [RLIMIT_LOCKS]      = "RLIMIT_LOCKS",
+        [RLIMIT_SIGPENDING] = "RLIMIT_SIGPENDING",
+        [RLIMIT_MSGQUEUE]   = "RLIMIT_MSGQUEUE",
+        [RLIMIT_NICE]       = "RLIMIT_NICE",
+        [RLIMIT_RTPRIO]     = "RLIMIT_RTPRIO",
+        [RLIMIT_RTTIME]     = "RLIMIT_RTTIME",
     };
 
     return limits[limit];

--- a/limits.c
+++ b/limits.c
@@ -48,15 +48,17 @@ static const gchar * limit_to_str(uint8_t limit)
         [RLIMIT_CORE]       = "RLIMIT_CORE",
         [RLIMIT_RSS]        = "RLIMIT_RSS",
         [RLIMIT_NOFILE]     = "RLIMIT_NOFILE",
-        [RLIMIT_AS]         = "RLIMIT_AS",
         [RLIMIT_NPROC]      = "RLIMIT_NPROC",
         [RLIMIT_MEMLOCK]    = "RLIMIT_MEMLOCK",
+#ifdef __linux__
+        [RLIMIT_AS]         = "RLIMIT_AS",
         [RLIMIT_LOCKS]      = "RLIMIT_LOCKS",
         [RLIMIT_SIGPENDING] = "RLIMIT_SIGPENDING",
         [RLIMIT_MSGQUEUE]   = "RLIMIT_MSGQUEUE",
         [RLIMIT_NICE]       = "RLIMIT_NICE",
         [RLIMIT_RTPRIO]     = "RLIMIT_RTPRIO",
         [RLIMIT_RTTIME]     = "RLIMIT_RTTIME",
+#endif
     };
 
     return limits[limit];

--- a/proc.c
+++ b/proc.c
@@ -22,7 +22,9 @@
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif
 #include <stdbool.h>
 #include <string.h>
 #include <fcntl.h>
@@ -50,8 +52,10 @@ static void configure_child_limits(gpointer userdata)
         }
     }
 
+#ifdef __linux__
     // Try to cleanup if we get killed.
     prctl(PR_SET_PDEATHSIG, SIGKILL);
+#endif
 
     // Make sure we create a new pgrp so that we can kill all subprocesses.
     setpgid(0, 0);

--- a/proc.c
+++ b/proc.c
@@ -35,6 +35,7 @@
 
 #include "proc.h"
 #include "flags.h"
+#include "util.h"
 
 // This file is part of halfempty - a fast, parallel testcase minimization tool.
 //
@@ -84,7 +85,7 @@ static gboolean write_pipe(gint pipefd, gint datafd, gsize size, goffset dataoff
     g_debug("starting splice(%d, %lu, %d, NULL, %lu, 0);", datafd, dataoffset, pipefd, size);
 
     while (size > 0) {
-        result = splice(datafd, &dataoffset, pipefd, NULL, size, 0);
+        result = g_splice(datafd, dataoffset, pipefd, size);
 
         // g_debug("splice(%d, %u, %d, NULL, %u, 0) => %d", datafd, dataoffset, pipefd, size, result);
 

--- a/proc.c
+++ b/proc.c
@@ -21,7 +21,6 @@
 #include <sys/uio.h>
 #include <sys/resource.h>
 #include <sys/types.h>
-#include <sys/sendfile.h>
 #include <sys/wait.h>
 #include <sys/prctl.h>
 #include <stdbool.h>

--- a/proc.c
+++ b/proc.c
@@ -93,7 +93,7 @@ static gboolean write_pipe(gint pipefd, gint datafd, gsize size, goffset dataoff
         g_close(pipefd, NULL);
     }
 
-    // Probably broken pipe? I think this is okay, but should check thats the real reason
+    // Probably broken pipe? I think this is okay, but should check that's the real reason
     if (size != 0) {
         g_debug("failed to splice all the data requested into pipe %ld remaining, %m", size);
     }
@@ -106,13 +106,13 @@ static gboolean write_pipe(gint pipefd, gint datafd, gsize size, goffset dataoff
 // It's pretty normal for programs to take too long to process their input, so
 // we need an option to support timeouts. I think --limit RLIMIT_CPU=10 works
 // quite intuitively, but cannot be caught by users if they want to clean
-// up and doesnt do anything if the process gets stuck blocking on something.
+// up and doesn't do anything if the process gets stuck blocking on something.
 //
 // We effectively want to run alarm() in the child, users can catch it (with
-// trap) and cleanup, or just let it terminate everything if they dont care.
-// But... alarm() wont work.  That only delivers a signal to the pgrp leader,
+// trap) and cleanup, or just let it terminate everything if they don't care.
+// But... alarm() won't work.  That only delivers a signal to the pgrp leader,
 // which is not what anyone expects (they would expect all subprocesses to be
-// cleaned up). I cant just write some code to catch that signal and forward
+// cleaned up). I can't just write some code to catch that signal and forward
 // it to the pgrp, because obviously that would be reset on execve. :-(
 //
 // I think there are only two options:
@@ -126,7 +126,7 @@ static gboolean write_pipe(gint pipefd, gint datafd, gsize size, goffset dataoff
 //
 //      Now the signal would work as expected, but not everyone is familiar
 //      with this syntax, and it seems like a lot to ask for such a basic thing
-//      as timeouts. I dont think many people understand pgrps, so it might be
+//      as timeouts. I don't think many people understand pgrps, so it might be
 //      kinda confusing.
 //
 //      2. I have a "timeout thread" that runs alarm() with a signal handler

--- a/proc.c
+++ b/proc.c
@@ -29,7 +29,9 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
+#ifdef __linux__
 #include <sys/personality.h>
+#endif
 
 #include "proc.h"
 #include "flags.h"
@@ -60,8 +62,10 @@ static void configure_child_limits(gpointer userdata)
     // Make sure we create a new pgrp so that we can kill all subprocesses.
     setpgid(0, 0);
 
+#ifdef __linux__
     // Try to be as consistent as possible.
     personality(personality(~0) | ADDR_NO_RANDOMIZE);
+#endif
 
     // Useful to help debug synchronization problems.
     if (kSleepSeconds)

--- a/tree.c
+++ b/tree.c
@@ -127,7 +127,7 @@ gboolean build_bisection_tree(gint fd, strategy_cb_t callback, gint *outfd, gulo
         // Take the treelock so we can modify the tree.
         g_mutex_lock(&treelock);
 
-        // Dont generate too much work or we'll explore too far down a wrong path.
+        // Don't generate too much work or we'll explore too far down a wrong path.
         // This condition is always signaled when a workunit completes.
         while (g_thread_pool_unprocessed(threadpool) > kMaxUnprocessed)
             g_cond_wait(&treecond, &treelock);
@@ -291,9 +291,9 @@ void cleanup_orphaned_tasks(task_t *task)
 
     g_mutex_lock(&task->mutex);
 
-    g_debug("thread %p aquired lock on task %p, state %s", g_thread_self(), task, string_from_status(task->status));
+    g_debug("thread %p acquired lock on task %p, state %s", g_thread_self(), task, string_from_status(task->status));
 
-    // It doesn't matter what state it is right now, we dont care.
+    // It doesn't matter what state it is right now, we don't care.
     task->status = TASK_STATUS_DISCARDED;
 
     // We hold the lock on this task now, so can clean up the file descriptor and zombie.
@@ -301,7 +301,7 @@ void cleanup_orphaned_tasks(task_t *task)
 
     if (task->childpid > 0) {
         if (waitpid(task->childpid, NULL, WNOHANG) != task->childpid) {
-            g_critical("waitpid() didnt return immediately with zombie, this shouldnt happen");
+            g_critical("waitpid() didn't return immediately with zombie, this shouldn't happen");
         }
     }
 
@@ -323,7 +323,7 @@ void abort_pending_tasks(GNode *root)
 
     gboolean abort_task_helper(GNode *node, gpointer data)
     {
-        // We cant lock tasks here or we would deadlock, so push them on a
+        // We can't lock tasks here or we would deadlock, so push them on a
         // queue to cleanup later.
         if (node->data) {
             g_thread_pool_push(cleanup, node->data, NULL);
@@ -410,7 +410,7 @@ void process_execute_jobs(GNode *node)
                  // Update status.
                  task->status = TASK_STATUS_SUCCESS;
 
-                 // We dont need to hold the lock anymore.
+                 // We don't need to hold the lock anymore.
                  g_mutex_unlock(&task->mutex);
 
                  // Any tasks on the failure branch were mispredicted.
@@ -452,7 +452,7 @@ static gdouble path_total_elapsed(GNode *node)
 {
     gdouble elapsed = 0;
 
-    // Dont call me on random nodes, must be finalized.
+    // Don't call me on random nodes, must be finalized.
     g_assert(root_path_finalized(node));
 
     for (; !G_NODE_IS_ROOT(node); node = node->parent) {
@@ -481,7 +481,7 @@ static void show_tree_statistics(void)
     if (kGenerateDotFile) {
         gchar dotfile[] = "finaltree.XXXXXX.dot";
 
-        // I dont want the descriptor, just the filename.
+        // I don't want the descriptor, just the filename.
         g_close(g_mkstemp(dotfile), NULL);
 
         g_print("Generating DOT file of final tree to %s (view it with xdot)...", dotfile);
@@ -603,7 +603,7 @@ static void cleanup_tree(void)
 {
     g_mutex_lock(&treelock);
 
-    g_debug("cleanup_tree() aquired lock, about to free all resources");
+    g_debug("cleanup_tree() acquired lock, about to free all resources");
 
     gboolean cleanup_tree_helper(GNode *node, gpointer user)
     {

--- a/tree.c
+++ b/tree.c
@@ -21,7 +21,6 @@
 #include <sys/uio.h>
 #include <sys/resource.h>
 #include <sys/types.h>
-#include <sys/sendfile.h>
 #include <sys/wait.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/util.c
+++ b/util.c
@@ -215,7 +215,11 @@ gboolean g_sendfile_all(gint outfd, gint infd, goffset offset, gsize count)
 // A more convenient wrapper for splice.
 gssize g_splice(gint infd, goffset offset, gint outfd, gsize count)
 {
+#ifdef __linux__
     return splice(infd, &offset, outfd, NULL, count, 0);
+#else
+    return g_sendfile(outfd, infd, offset, count);
+#endif
 }
 
 // Empty log handler to silence messages.

--- a/util.c
+++ b/util.c
@@ -171,6 +171,12 @@ gboolean g_sendfile_all(gint outfd, gint infd, goffset offset, gsize count)
     return sendfile(outfd, infd, &offset, count) == count;
 }
 
+// A more convenient wrapper for splice.
+gssize g_splice(gint infd, goffset offset, gint outfd, gsize count)
+{
+    return splice(infd, &offset, outfd, NULL, count, 0);
+}
+
 // Empty log handler to silence messages.
 void g_log_null_handler(const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data)
 {

--- a/util.h
+++ b/util.h
@@ -25,6 +25,7 @@ gboolean generate_dot_tree(GNode *root, gchar *filename);
 gint g_unlinked_tmp(GError **error);
 gssize g_sendfile(gint outfd, gint infd, goffset offset, gsize count);
 gboolean g_sendfile_all(gint outfd, gint infd, goffset offset, gsize count);
+gssize g_splice(gint infd, goffset offset, gint outfd, gsize count);
 void g_log_null_handler(const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data);
 void g_print_quiet(const gchar *string);
 void g_clearline(void);

--- a/zero.c
+++ b/zero.c
@@ -22,7 +22,6 @@
 #include <sys/uio.h>
 #include <sys/resource.h>
 #include <sys/types.h>
-#include <sys/sendfile.h>
 #include <sys/wait.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/zero.c
+++ b/zero.c
@@ -72,7 +72,7 @@ static task_t * strategy_zero_data(GNode *node)
     task_t *source = parent;            // Where we get our data from.
     guint   adjust = 0;                 // How many times we tried to fit a chunk.
 
-    // We dont hold the lock on parent, but user data will never change.
+    // We don't hold the lock on parent, but user data will never change.
     bisect_t *parentstatus  = parent->user;
     bisect_t *childstatus   = g_new0(bisect_t, 1);
 
@@ -126,7 +126,7 @@ static task_t * strategy_zero_data(GNode *node)
 
     // Here is the problem, it's pointless trying to zero out chunks we've
     // already zeroed out. This means we need to start at the root, and see if
-    // our offset + chunksize is already inside a SUCCESS node (dont care about
+    // our offset + chunksize is already inside a SUCCESS node (don't care about
     // FAIL, because we're smaller).
     for (GNode *current = node; !G_NODE_IS_ROOT(current); current = current->parent) {
         gboolean adjusted = false;
@@ -225,7 +225,7 @@ static task_t * strategy_zero_data(GNode *node)
     // If it's success, the fd must be open and valid.
     g_assert_cmpint(source->fd, !=, -1);
 
-    // This cannot possible be wrong.
+    // This cannot possibly be wrong.
     g_assert_cmpuint(source->size, ==, g_file_size(source->fd));
 
     // OK, we can do a bisection now.
@@ -234,7 +234,7 @@ static task_t * strategy_zero_data(GNode *node)
     // Size should never change for this strategy.
     child->size = source->size;
 
-    // i didnt think this was possible because how can child be smaller than an ancestor?
+    // i didn't think this was possible because how can child be smaller than an ancestor?
     if (childstatus->offset > source->size)
         goto nochildunlock;
 


### PR DESCRIPTION
This PR contains changes necessary to run Halfempty on macOS 10.13.6.

This tool surfaced just at a crucial time that I needed to do some non-trivial test case minimization, so firstly thank you :)

While I think the commits in this PR are relatively fine-grained and well explained, this patch series admittedly conflates several things:
* hiding or providing alternatives for Linux-isms
* suppressing compiler warnings
* Clang compatibility

Specifically I think it's worth calling out the following suboptimal things:
* on non-Linux, `sendfile` is now a read-then-write loop. Apart from being less efficient I find this logic quite fiddly, so did I get it right?
* on non-Linux, children do not get `SIGKILL`ed automatically. Offhand I don't know how to implement this in a portable way.
* on non-Linux, ASLR is left enabled. I'm not sure how to cleanly implement this on macOS, though as I indicated in my commit message there may be a trick to borrow from GDB here.

I only lightly tested this by using it to minimize the example use case I had on hand. In particular I didn't test any of the dot/monitor functionality as I didn't need it and didn't know what exactly I should look for when testing. Please let me know if there's specific things I should test or if you'd like these commits edited.