### PR TITLE
Portability changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ ifeq ($(findstring Microsoft,$(shell uname -r)), Microsoft)
     EXTRA = splice_generic.o sendfile_generic.o
 endif
 
+ifeq ($(shell uname),NetBSD)
+    EXTRA = sendfile_generic.o splice_generic.o
+endif
+
 halfempty: proc.o bisect.o util.o zero.o tree.o flags.o halfempty.o limits.o $(EXTRA)
 
 util.o: monitor.h util.c

--- a/bisect.c
+++ b/bisect.c
@@ -202,7 +202,7 @@ static task_t * strategy_bisect_data(GNode *node)
                        source->fd,
                        0,
                        childstatus->offset) == false) {
-        g_error("sendfile failed while trying to construct new file, %m");
+        g_error("sendfile failed while trying to construct new file, %s", strerror(errno));
         goto nochildunlock;
     }
 
@@ -215,7 +215,7 @@ static task_t * strategy_bisect_data(GNode *node)
                            source->size
                                 - childstatus->chunksize
                                 - childstatus->offset) == false) {
-            g_error("sendfile failed while trying to construct new file, %m");
+            g_error("sendfile failed while trying to construct new file, %s", strerror(errno));
             goto nochildunlock;
         }
 

--- a/limits.c
+++ b/limits.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/time.h>
@@ -127,7 +128,7 @@ static void __attribute__((constructor)) init_child_limits()
 
     for (gint i = 0; i < RLIMIT_NLIMITS; i++) {
         if (getrlimit(i, &kChildLimits[i]) != 0) {
-            g_warning("failed to getrlimit for %u, %m", i);
+            g_warning("failed to getrlimit for %u, %s", i, strerror(errno));
         }
 
         g_debug("Configured rlimit %s => { %llu, %llu }",

--- a/proc.c
+++ b/proc.c
@@ -55,7 +55,7 @@ static void configure_child_limits(gpointer userdata)
     }
 
     // Make sure we create a new pgrp so that we can kill all subprocesses.
-    setpgrp();
+    setpgid(0, 0);
 
 #ifdef __linux__
     // Try to cleanup if we get killed.

--- a/proc.c
+++ b/proc.c
@@ -50,7 +50,7 @@ static void configure_child_limits(gpointer userdata)
     // Some of these may fail, not sure what to do.
     for (gint i = 0; i < RLIMIT_NLIMITS; i++) {
         if (setrlimit(i, &kChildLimits[i]) == -1) {
-            g_critical("a call to setrlimit for %u failed(), %m", i);
+            g_critical("a call to setrlimit for %u failed(), %s", i, strerror(errno));
         }
     }
 

--- a/util.c
+++ b/util.c
@@ -129,7 +129,7 @@ gboolean generate_dot_tree(GNode *root, gchar *filename)
     FILE *out = fopen(filename, "w");
 
     if (!out) {
-        g_warning("failed to open file `%s` to save dot file, %m", filename);
+        g_warning("failed to open file `%s` to save dot file, %s", filename, strerror(errno));
         return false;
     }
 


### PR DESCRIPTION
I tried building halfempty on NetBSD and could fix two problems:
````
warning: %m is only allowed in syslog(3) like functions [-Wformat=]
````
and
````
proc.c:58:5: error: too few arguments to function 'setpgrp'
     setpgrp();
     ^~~~~~~
````
Two others remain for which I'll open an issue.