### PR TITLE
Add an option to generate 'intermediate' results

### DIFF
--- a/flags.c
+++ b/flags.c
@@ -97,6 +97,9 @@ guint kVerbosity = 0;
 // Minimize all informational messages, try to only print errors.
 gboolean kQuiet = false;
 
+// When a new, smaller tree is found, write-out to 'kOutputFile' as we go
+gboolean kGenerateIntermediateFile = false;
+
 // Verify the input task is sane.
 gboolean kVerifyInput = true;
 

--- a/flags.h
+++ b/flags.h
@@ -45,6 +45,7 @@ extern gboolean kContinueSearch;
 extern gboolean kIterateUntilStable;
 extern guint kVerbosity;
 extern gboolean kQuiet;
+extern gboolean kGenerateIntermediateFile;
 extern gboolean kVerifyInput;
 extern guint kSleepSeconds;
 extern struct rlimit kChildLimits[RLIMIT_NLIMITS];

--- a/halfempty.c
+++ b/halfempty.c
@@ -141,6 +141,9 @@ static const GOptionEntry kStandardOptions[] = {
     { "monitor", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kMonitorMode,
         "Monitor progress in your web browser (default=false).",
         NULL },
+    { "gen-intermediate", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kGenerateIntermediateFile,
+        "Generate intermediate (reduced) files while processing (default=false).",
+        NULL },
     { NULL },
 };
 


### PR DESCRIPTION
## Issue

One nice feature of `creduce` is that it generates 'intermediate' results as it goes.

This has a few benefits/use-cases:

- you can (manually) terminate the reduction process (e.g., you want to try something else but not lose your current status), and still have a partially reduced output

- if something goes wrong (e.g., you fill up `/tmp`), then you still have a partially reduced output

- if you want to keep an eye on the reduction process, you can see what's been done so far

- if you want to double-triple-check that your script is working, you can validate in-progress results, by running your test script on the current output

Unfortunately, `halfempty` only generates output once the whole process has finished (well, you can spy on `/proc/<process>/fd/<pick one>` but that's not idea). 

## Description of changes

This PR adds an option `--gen-intermediate` to `halfempty`, such that it will write-out the current, smallest tree (when a new, smaller tree is found) to the file specified in `--output` (or the default of `halfempty.out`).

### Example

```
/path/to/halfempty --gen-intermediate script.sh input.c
```

will generate a `halfempty.out` while `halfempty` is still reducing.


Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>