### PR TITLE
Using 'g_message' over 'g_print' to allow for stdout to be flushed when writing output to a file

### DIFF
--- a/halfempty.c
+++ b/halfempty.c
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
     kProcessThreads = g_get_num_processors() + 1;
 
     // Setup a print handler that respects the kQuiet parameter.
-    g_set_print_handler(g_print_quiet);
+    g_set_print_handler(g_message_quiet);
 
     threadopts  = g_option_group_new("threads",
                                      "Fine tune performance options:",
@@ -301,7 +301,7 @@ int main(int argc, char **argv)
 
         // Iterate over all available strategies.
         for (gint k = 0; k < kNumStrategies; k++) {
-            g_print("Input file \"%s\" is now %lu bytes, starting strategy \"%s\"...",
+            g_message("Input file \"%s\" is now %lu bytes, starting strategy \"%s\"...",
                     kInputFile,
                     g_file_size(fd),
                     kStrategyList[k].name);
@@ -315,25 +315,25 @@ int main(int argc, char **argv)
                 return EXIT_FAILURE;
             }
 
-            g_print("");
+            g_message("");
 
-            g_print("Strategy \"%s\" complete, output %lu bytes",
+            g_message("Strategy \"%s\" complete, output %lu bytes",
                     kStrategyList[k].name,
                     g_file_size(fd));
         }
 
         if (kIterateUntilStable && g_file_size(fd) < originalsize) {
-            g_print("Minimization succeeded, testing if minimization is stable...\n");
+            g_message("Minimization succeeded, testing if minimization is stable...\n");
             continue;
         } else if (kIterateUntilStable) {
-            g_print("Minimization stable, all work done.\n");
+            g_message("Minimization stable, all work done.\n");
         }
 
         // All done.
         break;
     }
 
-    g_print("All work complete, generating output %s (size: %lu)",
+    g_message("All work complete, generating output %s (size: %lu)",
             kOutputFile,
             g_file_size(fd));
 

--- a/tree.c
+++ b/tree.c
@@ -113,7 +113,7 @@ gboolean build_bisection_tree(gint fd,
 
     // Verify the input task is sane.
     if (kVerifyInput) {
-        g_print("Verifying the original input executes successfully... (skip with --noverify)");
+        g_message("Verifying the original input executes successfully... (skip with --noverify)");
         process_execute_jobs(tree);
         if (root->status != TASK_STATUS_SUCCESS) {
             g_message("This program expected `%s` to return successfully",
@@ -127,7 +127,7 @@ gboolean build_bisection_tree(gint fd,
                       kCommandPath);
             return false;
         } else {
-            g_print("The original input file succeeded after %.1f seconds.",
+            g_message("The original input file succeeded after %.1f seconds.",
                     g_timer_elapsed(root->timer, NULL));
         }
     } else {
@@ -306,7 +306,7 @@ gboolean build_bisection_tree(gint fd,
         continue;
 
     finalized:
-        g_print("Reached the end of our path through tree, "
+        g_message("Reached the end of our path through tree, "
                 "all nodes were finalized");
 
         // Unlock the tree and let threadpool workers finish.
@@ -604,7 +604,7 @@ static void show_tree_statistics(void)
         // I don't want the descriptor, just the filename.
         g_close(g_mkstemp(dotfile), NULL);
 
-        g_print("Generating DOT file of final tree to %s (view it with xdot)...",
+        g_message("Generating DOT file of final tree to %s (view it with xdot)...",
                 dotfile);
 
         generate_dot_tree(tree, dotfile);
@@ -624,12 +624,12 @@ static void show_tree_statistics(void)
                     analyze_tree_helper,
                     &stats);
 
-    g_print("%u nodes failed, %u worked, %u discarded, %u collapsed",
+    g_message("%u nodes failed, %u worked, %u discarded, %u collapsed",
             stats.failure,
             stats.success,
             stats.discarded,
             g_node_n_nodes(retired, G_TRAVERSE_ALL));
-    g_print("%0.3f seconds of compute was required for final path",
+    g_message("%0.3f seconds of compute was required for final path",
             stats.elapsed);
 
     g_mutex_unlock(&treelock);
@@ -929,7 +929,7 @@ static gint print_status_message(GTimer *elapsed, gint finaldepth)
 
     if (g_node_depth(finalnode) > finaldepth) {
         finaldepth = g_node_depth(finalnode);
-        g_print("New finalized size: %lu (depth=%u) real=%.1fs, user=%.1fs, speedup=~%.1fs",
+        g_message("New finalized size: %lu (depth=%u) real=%.1fs, user=%.1fs, speedup=~%.1fs",
                 finaltask->size,
                 g_node_depth(finalnode)
                     + g_node_n_nodes(retired, G_TRAVERSE_ALL),

--- a/util.c
+++ b/util.c
@@ -55,7 +55,7 @@ gsize g_file_size(gint fd)
     return buf.st_size;
 }
 
-void g_print_quiet(const gchar *string)
+void g_message_quiet(const gchar *string)
 {
     if (!kQuiet) {
         g_clearline();

--- a/util.h
+++ b/util.h
@@ -30,7 +30,7 @@ void g_log_null_handler(const gchar *log_domain,
                         GLogLevelFlags log_level,
                         const gchar *message,
                         gpointer user_data);
-void g_print_quiet(const gchar *string);
+void g_message_quiet(const gchar *string);
 void g_clearline(void);
 gboolean generate_monitor_image(GNode *root);
 


### PR DESCRIPTION
## Issue

If you redirect the output of `halfempty` directly into a file (e.g., to run it in a background process, and where you might want to `tail -f` the output) then `halfempty`'s use of `g_print` means that this output does not get flushed.

This means that it is not possible to run `halfempty` with stdout redirected to a file.

## Description of changes

This PR changes all-but-one of `halfempty`'s calls to `g_print` with `g_message`, which "immediately" writes to stdout.

The "banner" call to `g_print` was **not** changed because it seems that `g_message` does not (completely) handle the control characters to draw the banner. As such, if you redirect `halfempty`'s output to a file, you are unlikely to see the banner ¯\\_(ツ)_/¯

### Example

```
/path/to/halfempty script.sh input.c |& cat > log.txt
```

will now populate `log.txt` as `halfempty` is still reducing.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>