### PR TITLE
Add an option to ensure that stdout is only line buffered

### DIFF
--- a/flags.c
+++ b/flags.c
@@ -100,6 +100,9 @@ gboolean kQuiet = false;
 // When a new, smaller tree is found, write-out to 'kOutputFile' as we go
 gboolean kGenerateIntermediateFile = false;
 
+// If true, call 'setvbuf' to ensure that stdout is not line buffered
+gboolean kLineBuffered = false;
+
 // Verify the input task is sane.
 gboolean kVerifyInput = true;
 

--- a/flags.h
+++ b/flags.h
@@ -46,6 +46,7 @@ extern gboolean kIterateUntilStable;
 extern guint kVerbosity;
 extern gboolean kQuiet;
 extern gboolean kGenerateIntermediateFile;
+extern gboolean kLineBuffered;
 extern gboolean kVerifyInput;
 extern guint kSleepSeconds;
 extern struct rlimit kChildLimits[RLIMIT_NLIMITS];

--- a/halfempty.c
+++ b/halfempty.c
@@ -144,6 +144,9 @@ static const GOptionEntry kStandardOptions[] = {
     { "gen-intermediate", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kGenerateIntermediateFile,
         "Generate intermediate (reduced) files while processing (default=false).",
         NULL },
+    { "line-buffered", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &kLineBuffered,
+        "Ensure that stdout is only line buffered (default=false).",
+        NULL },
     { NULL },
 };
 
@@ -178,6 +181,12 @@ int main(int argc, char **argv)
 
     // Setup some default options.
     kProcessThreads = g_get_num_processors() + 1;
+
+    // ensure that we only buffer stdout up to one line
+    if (kLineBuffered == true)
+    {
+        setvbuf(stdout, NULL, _IOLBF, 0);
+    }
 
     // Setup a print handler that respects the kQuiet parameter.
     g_set_print_handler(g_print_quiet);


### PR DESCRIPTION
## Issue

If you redirect the output of `halfempty` directly into a file (e.g., to run it in a background process, and where you might want to `tail -f` the output) then `halfempty`'s eventual use of `puts` seems to lead to output being severely (entirely?) buffered.

This means that it is not possible to run `halfempty` with stdout redirected to a file.

## Description of changes

This PR adds an option `--line-buffered`, which will then mean that `setvbuf` is called in `main` to ensure that stdout is only line buffered.

### Example

```
/path/to/halfempty --line-buffered script.sh input.c |& cat > log.txt
```

will now populate `log.txt` as `halfempty` is still reducing.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>